### PR TITLE
Fix delete paymentschedule when bill is deleted

### DIFF
--- a/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
+++ b/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
@@ -97,8 +97,8 @@ class InterfacePaymentScheduletrigger
             return $langs->trans("Unknown");
         }
     }
-	
-	
+
+
 	/**
 	 * Function called when a Dolibarrr business event is done.
 	 * All functions "run_trigger" are triggered if file is inside directory htdocs/core/triggers
@@ -114,8 +114,8 @@ class InterfacePaymentScheduletrigger
 		//For 8.0 remove warning
 		$result=$this->run_trigger($action, $object, $user, $langs, $conf);
 		return $result;
-	}	
-		
+	}
+
 
     /**
      * Function called when a Dolibarrr business event is done.
@@ -498,6 +498,14 @@ class InterfacePaymentScheduletrigger
             dol_syslog(
                 "Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id
             );
+            $paymentschedule = new PaymentSchedule($this->db);
+            if ($paymentschedule->fetchBy($object->id, 'fk_facture') > 0) {
+                if ($paymentschedule->delete($user) <= 0) {
+                    setEventMessages($langs->trans('PaymentScheduleDeleteFailed', $paymentschedule->id, $object->id));
+                }
+            }
+
+
         } elseif ($action == 'LINEBILL_INSERT') {
             dol_syslog(
                 "Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id

--- a/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
+++ b/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
@@ -498,10 +498,18 @@ class InterfacePaymentScheduletrigger
             dol_syslog(
                 "Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id
             );
+            if (!defined('INC_FROM_DOLIBARR')) define('INC_FROM_DOLIBARR', 1);
+            dol_include_once('paymentschedule/config.php');
+            dol_include_once('paymentschedule/class/paymentschedule.class.php');
+
             $paymentschedule = new PaymentSchedule($this->db);
             if ($paymentschedule->fetchBy($object->id, 'fk_facture') > 0) {
                 if ($paymentschedule->delete($user) <= 0) {
-                    setEventMessages($langs->trans('PaymentScheduleDeleteFailed', $paymentschedule->id, $object->id));
+                    setEventMessages(
+                        $langs->trans('PaymentScheduleDeleteFailed', $paymentschedule->id, $object->id),
+                        array(),
+                        'errors'
+                    );
                 }
             }
 

--- a/langs/en_US/paymentschedule.lang
+++ b/langs/en_US/paymentschedule.lang
@@ -132,6 +132,7 @@ CheckErrorNoActiveLineOnContract=The related contract has no active lines
 CanNotRetrieveInvoice=Unable to fetch the related invoice
 CheckErrorInvoiceInsufficientPermission=Rejected (please check user rights)
 PaymentScheduleIsValidated=The payment plan is validated
+PaymentScheduleDeleteFailed=Unable to delete payment plan %d linked with invoice %d
 
 # WARNINGS
 PaymentSchedule_Warnings_checkDateOrPaymentType=Please check the date you entered and/or the payment methods allowed in the module configuration

--- a/langs/fr_FR/paymentschedule.lang
+++ b/langs/fr_FR/paymentschedule.lang
@@ -132,6 +132,7 @@ CheckErrorNoActiveLineOnContract=Le contrat lié n'a aucune ligne active
 CanNotRetrieveInvoice=Impossible de récupérer la facture liée
 CheckErrorInvoiceInsufficientPermission=Permission insuffisante
 PaymentScheduleIsValidated=L'échéancier est au statut validé
+PaymentScheduleDeleteFailed=Impossible de supprimer l’échéancier %d lié à la facture %d
 
 # WARNINGS
 PaymentSchedule_Warnings_checkDateOrPaymentType=Veuillez vérifier la date saisie et/ou les types de paiements autorisés en configuration du module


### PR DESCRIPTION
The `BILL_DELETE` trigger was missing. If the user deletes the latest invoice (technically the only one that can be deleted), the related payment schedule should be deleted if it exists.

Aside: I don't really know what the line below stands for (I added it simply because the trigger above has it too). Apparently it is not harmful (I tested the behaviour before opening the PR), but maybe it is useless. Please tell me so if it is.
```php
if (!defined('INC_FROM_DOLIBARR')) define('INC_FROM_DOLIBARR', 1);
```