### PR TITLE
Fix tk11838 link payment to schedule det

### DIFF
--- a/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
+++ b/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
@@ -538,50 +538,56 @@ class InterfacePaymentScheduletrigger
                 dol_include_once('paymentschedule/config.php');
                 dol_include_once('paymentschedule/class/paymentschedule.class.php');
 
-                //pour chaque montant du paiement
-                foreach($object->amounts as $facid=>$amount)
+
+                if(!empty($object->amounts))
                 {
-                    if (empty($paymentschedule_facs))
+                    //pour chaque montant du paiement
+                    foreach ($object->amounts as $facid => $amount)
                     {
-                        $psbonprelevement = new PaymentScheduleBonPrelevement($this->db);
-                        $psbonprelevement->fetch($object->id_prelevement);
-
-                        $paymentschedule_facs = $psbonprelevement->getListInvoices(1);
-//                        $paymentschedule_facs_index = 0;
-                    }
-
-                    //on sélectionner le dernier créé en fonction de l'id du paiement et de l'id de la facture en cours
-                    $fk_paiement_facture = null;
-                    $sql = 'SELECT rowid FROM '.MAIN_DB_PREFIX.'paiement_facture WHERE fk_paiement = '.$object->id.' AND fk_facture ='.$facid.' ORDER BY rowid DESC LIMIT 1';
-                    $resql = $this->db->query($sql);
-                    if ($resql)
-                    {
-                        while ($obj = $this->db->fetch_object($resql))
+                        if (empty($paymentschedule_facs))
                         {
-                            $fk_paiement_facture = $obj->rowid;
-                        }
-                    }
+                            $psbonprelevement = new PaymentScheduleBonPrelevement($this->db);
+                            $psbonprelevement->fetch($object->id_prelevement);
 
-                    //on cherche le tableau d'infos pour facture en cours
-                    foreach($paymentschedule_facs as $paymentschedule_fac){
-                        if($paymentschedule_fac[0] == $facid){
-                            $TInfo = $paymentschedule_fac;
-                            break;
+                            $paymentschedule_facs = $psbonprelevement->getListInvoices(1);
+//                        $paymentschedule_facs_index = 0;
                         }
-                    }
+
+                        //on sélectionner le dernier créé en fonction de l'id du paiement et de l'id de la facture en cours
+                        $fk_paiement_facture = null;
+                        $sql = 'SELECT rowid FROM '.MAIN_DB_PREFIX.'paiement_facture WHERE fk_paiement = '.$object->id.' AND fk_facture ='.$facid.' ORDER BY rowid DESC LIMIT 1';
+                        $resql = $this->db->query($sql);
+                        if ($resql)
+                        {
+                            while ($obj = $this->db->fetch_object($resql))
+                            {
+                                $fk_paiement_facture = $obj->rowid;
+                            }
+                        }
+
+                        //on cherche le tableau d'infos pour facture en cours
+                        foreach ($paymentschedule_facs as $paymentschedule_fac)
+                        {
+                            if ($paymentschedule_fac[0] == $facid)
+                            {
+                                $TInfo = $paymentschedule_fac;
+                                break;
+                            }
+                        }
 
 //                    $TInfo = $paymentschedule_facs[$paymentschedule_facs_index];
-                    if (!empty($TInfo) && !empty($fk_paiement_facture))
-                    {
-                        $paymentscheduledet = new PaymentScheduleDet($this->db);
-                        // [2] = fk_prelevement_lignes
-                        if ($paymentscheduledet->fetchBySourceElement($TInfo[2], 'widthdraw_line') > 0)
+                        if (!empty($TInfo) && !empty($fk_paiement_facture))
                         {
-                            $paymentscheduledet->add_object_linked('paymentdet', $fk_paiement_facture);
-                            $paymentscheduledet->setAccepted($user);
-                        }
+                            $paymentscheduledet = new PaymentScheduleDet($this->db);
+                            // [2] = fk_prelevement_lignes
+                            if ($paymentscheduledet->fetchBySourceElement($TInfo[2], 'widthdraw_line') > 0)
+                            {
+                                $paymentscheduledet->add_object_linked('paymentdet', $fk_paiement_facture);
+                                $paymentscheduledet->setAccepted($user);
+                            }
 
 //                        $paymentschedule_facs_index++;
+                        }
                     }
                 }
 

--- a/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
+++ b/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
@@ -538,20 +538,23 @@ class InterfacePaymentScheduletrigger
                 dol_include_once('paymentschedule/config.php');
                 dol_include_once('paymentschedule/class/paymentschedule.class.php');
 
+                if (empty($paymentschedule_facs))
+                {
+                    $psbonprelevement = new PaymentScheduleBonPrelevement($this->db);
+                    $res = $psbonprelevement->fetch($object->id_prelevement);
 
-                if(!empty($object->amounts))
+                    if($res)
+                    {
+                        $paymentschedule_facs = $psbonprelevement->getListInvoices(1);
+                    }
+//                        $paymentschedule_facs_index = 0;
+                }
+
+                if(!empty($object->amounts) && !empty($paymentschedule_facs))
                 {
                     //pour chaque montant du paiement
                     foreach ($object->amounts as $facid => $amount)
                     {
-                        if (empty($paymentschedule_facs))
-                        {
-                            $psbonprelevement = new PaymentScheduleBonPrelevement($this->db);
-                            $psbonprelevement->fetch($object->id_prelevement);
-
-                            $paymentschedule_facs = $psbonprelevement->getListInvoices(1);
-//                        $paymentschedule_facs_index = 0;
-                        }
 
                         //on sélectionner le dernier créé en fonction de l'id du paiement et de l'id de la facture en cours
                         $fk_paiement_facture = null;

--- a/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
+++ b/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
@@ -532,13 +532,13 @@ class InterfacePaymentScheduletrigger
 
             if (!empty($object->id_prelevement))
             {
-                global $paymentschedule_facs, $paymentschedule_facs_index;
+                global $paymentschedule_facs;
 
                 if (!defined('INC_FROM_DOLIBARR')) define('INC_FROM_DOLIBARR', 1);
                 dol_include_once('paymentschedule/config.php');
                 dol_include_once('paymentschedule/class/paymentschedule.class.php');
 
-
+                //pour chaque montant du paiement
                 foreach($object->amounts as $facid=>$amount)
                 {
                     if (empty($paymentschedule_facs))
@@ -547,10 +547,10 @@ class InterfacePaymentScheduletrigger
                         $psbonprelevement->fetch($object->id_prelevement);
 
                         $paymentschedule_facs = $psbonprelevement->getListInvoices(1);
-                        $paymentschedule_facs_index = 0;
+//                        $paymentschedule_facs_index = 0;
                     }
 
-                    // C'est pas terrible mais pas trop le choix, je récupère la dernière entrée pour l'utiliser et faire le lien
+                    //on sélectionner le dernier créé en fonction de l'id du paiement et de l'id de la facture en cours
                     $fk_paiement_facture = null;
                     $sql = 'SELECT rowid FROM '.MAIN_DB_PREFIX.'paiement_facture WHERE fk_paiement = '.$object->id.' AND fk_facture ='.$facid.' ORDER BY rowid DESC LIMIT 1';
                     $resql = $this->db->query($sql);
@@ -562,6 +562,7 @@ class InterfacePaymentScheduletrigger
                         }
                     }
 
+                    //on cherche le tableau d'infos pour facture en cours
                     foreach($paymentschedule_facs as $paymentschedule_fac){
                         if($paymentschedule_fac[0] == $facid){
                             $TInfo = $paymentschedule_fac;


### PR DESCRIPTION
Lorsqu'un bon de prélèvement est crédité, lors de la création d'un paiement, on associe le paiement à la ligne de l'échéancier de la facture concernée. Cependant, les paiements composés de plusieurs montants liés à des factures différentes n'étaient pas pris en compte, ce qui avait pour conséquence de tout décaler et d'associer les mauvais paiements aux lignes de l'échéancier. 

Correction : dans le trigger, on fait un taitement pour chaque montant du paiement qui vient d'être créé. On tient compte de l'id facture associé au montant afin de trouver les infos nécessaires pour créer le lien entre le paiement et la ligne de l'échéancier.