### PR TITLE
1.0 fix tk12123 reste a payer echeancier

### DIFF
--- a/class/paymentschedule.class.php
+++ b/class/paymentschedule.class.php
@@ -428,7 +428,6 @@ class PaymentSchedule extends SeedObject
 				break;
 			}
 
-			$tx_tva = $line->tva_tx;
 			$i++;
 		}
 
@@ -580,12 +579,15 @@ class PaymentSchedule extends SeedObject
 
 		//Calcul reste à payer
 
+		$totalpaye = 0;
+
 		// On verifie si la facture a des paiements
 		$sql = 'SELECT pf.amount';
 		$sql .= ' FROM ' . MAIN_DB_PREFIX . 'paiement_facture as pf';
 		$sql .= ' WHERE pf.fk_facture = ' . $facture->id;
 
 		$result = $this->db->query($sql);
+
 		if ($result) {
 			$i = 0;
 			$num = $this->db->num_rows($result);

--- a/class/paymentschedule.class.php
+++ b/class/paymentschedule.class.php
@@ -418,7 +418,21 @@ class PaymentSchedule extends SeedObject
 
         $TRestrictMessage = array();
 
-        if (empty($user->rights->paymentschedule->write)) $TRestrictMessage[] = $langs->trans('CheckErrorInvoiceInsufficientPermission');
+		//Interdire la création d'échéancier si les lignes de la facture ont plusieurs taux de TVA différents
+		$i = 0;
+		foreach($facture->lines as $line){
+			if(empty($i)) $tx_tva = $line->tva_tx;
+
+			if($tx_tva != $line->tva_tx) {
+				$TRestrictMessage[] = $langs->trans('CheckErrorInvoiceSeveralTva');
+				break;
+			}
+
+			$tx_tva = $line->tva_tx;
+			$i++;
+		}
+
+		if (empty($user->rights->paymentschedule->write)) $TRestrictMessage[] = $langs->trans('CheckErrorInvoiceInsufficientPermission');
 
         if ($facture->statut == Facture::STATUS_DRAFT) $TRestrictMessage[] = $langs->trans('CheckErrorInvoiceIsDraft');
 

--- a/langs/fr_FR/paymentschedule.lang
+++ b/langs/fr_FR/paymentschedule.lang
@@ -123,6 +123,7 @@ PaymentSchedule_selectFormatForWithdraw=Format pour le bon de prélèvement
 WidthdrawsLinked=Bons de prélèvement liés
 
 # ERRORS
+CheckErrorInvoiceSeveralTva=Cette facture possède des lignes avec des taux de TVA différents
 CheckErrorInvoiceIsDraft=Cette facture est au statut brouillon
 CheckErrorTimetableAlreadyExists=Un échéancier existe déjà pour cette facture
 CheckErrorCustomerHasNoIBAN=Le client de cette facture ne possède pas d'IBAN


### PR DESCRIPTION
# FIX Creation Echeancier : Reste à payer

- Interdiction de créer un écéhancier si il y a des lignes de la facture avec des taux de TVA différents (on ne gère pas le calcul HT et TVA de l'échéancier dans ce cas là)
- Prise en compte du "Reste à payer" de la facture lors de la création de l'échéancier au lieu du "Montant TTC" qui ne prend pas en compte les avoirs etc.