### PR TITLE
1.0 fix create credit transfer trigger

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,8 @@
+# CHANGELOG FOR PAYMENTSCHEDULE MODULE
+
+## Not Released
+
+
+## 1.0.3 - 09/04/2021
+
+- FIX : Add "CREDIT_TRANSFER_ORDER_CREATE" trigger to create bank direct debit

--- a/core/modules/modPaymentSchedule.class.php
+++ b/core/modules/modPaymentSchedule.class.php
@@ -59,7 +59,7 @@ class modPaymentSchedule extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module PaymentSchedule";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.0.2';
+		$this->version = '1.0.3';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
+++ b/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
@@ -159,7 +159,7 @@ class InterfacePaymentScheduletrigger
 
             $object->deleteObjectLinked();
 
-        } elseif ($action == 'BON_PRELEVEMENT_CREATE' || $action == 'DIRECT_DEBIT_ORDER_CREATE') {
+        } elseif ($action == 'BON_PRELEVEMENT_CREATE' || $action == 'DIRECT_DEBIT_ORDER_CREATE' || $action == 'CREDIT_TRANSFER_ORDER_CREATE') {
             dol_syslog(
                 "Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id
             );


### PR DESCRIPTION
Compatibilité avec les versions >= 12.0 => ajout trigger "CREDIT_TRANSFER_ORDER_CREATE" qui intervient lorsque le bon de prélèvement créé est de type "bank_transfer'