### PR TITLE
Fix paiement link for unique invoice paid

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Not Released
 
+- FIX: get payment table for payment link to just one invoice - *07/09/2021* - 1.1.1
 - NEW: compatibility with Dolibarr v13-v14 - *03/08/2021* - 1.1.0
 
 ## Version 1.0

--- a/core/modules/modPaymentSchedule.class.php
+++ b/core/modules/modPaymentSchedule.class.php
@@ -59,7 +59,7 @@ class modPaymentSchedule extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module PaymentSchedule";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.0';
+		$this->version = '1.1.1';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
+++ b/core/triggers/interface_99_modPaymentSchedule_PaymentScheduletrigger.class.php
@@ -547,10 +547,13 @@ class InterfacePaymentScheduletrigger
                     {
                         $paymentschedule_facs = $psbonprelevement->getListInvoices(1);
                     }
+
 //                        $paymentschedule_facs_index = 0;
                 }
 
-                if(!empty($object->amounts) && !empty($paymentschedule_facs))
+				if (empty($object->amounts)) $object->amounts = $object->getAmountsArray();
+
+				if(!empty($object->amounts) && !empty($paymentschedule_facs))
                 {
                     //pour chaque montant du paiement
                     foreach ($object->amounts as $facid => $amount)


### PR DESCRIPTION
FIX: get payment table for payment link to just one invoice
In this case, the field "amount" is populated but not amounts.
So the PaymentSheduleLines don't change there status => bug